### PR TITLE
Add exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following to your `build.gradle.kts` file to install KtUniversalis:
 
 ```kotlin
 dependencies {
-    implementation("cloud.drakon:ktuniversalis:1.0.0-SNAPSHOT")
+    implementation("cloud.drakon:ktuniversalis:1.0.0")
 }
 ```
 
@@ -26,7 +26,7 @@ dependencies {
 ### `package.json`
 
 ```json
-"ktuniversalis": "1.0.0-SNAPSHOT"
+"ktuniversalis": "1.0.0"
 ```
 
 #### Command line

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add the following to your `build.gradle.kts` file to install KtUniversalis:
 
 ```kotlin
 dependencies {
-    implementation("cloud.drakon:ktuniversalis:0.0.2")
+    implementation("cloud.drakon:ktuniversalis:1.0.0-SNAPSHOT")
 }
 ```
 
@@ -26,7 +26,7 @@ dependencies {
 ### `package.json`
 
 ```json
-"ktuniversalis": "0.0.2"
+"ktuniversalis": "1.0.0-SNAPSHOT"
 ```
 
 #### Command line

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = "cloud.drakon"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.0"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = "cloud.drakon"
-version = "0.0.2"
+version = "1.0.0-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/src/commonMain/kotlin/exception/InvalidEntriesException.kt
+++ b/src/commonMain/kotlin/exception/InvalidEntriesException.kt
@@ -1,0 +1,3 @@
+package cloud.drakon.ktuniversalis.exception
+
+class InvalidEntriesException(message: String): Throwable(message)

--- a/src/commonMain/kotlin/exception/InvalidParameterException.kt
+++ b/src/commonMain/kotlin/exception/InvalidParameterException.kt
@@ -1,0 +1,7 @@
+package cloud.drakon.ktuniversalis.exception
+
+/**
+ * The parameters are invalid
+ */
+class InvalidParameterException(message: String = "The parameters are invalid"):
+    Throwable(message)

--- a/src/commonMain/kotlin/exception/InvalidWorldDcException.kt
+++ b/src/commonMain/kotlin/exception/InvalidWorldDcException.kt
@@ -1,0 +1,7 @@
+package cloud.drakon.ktuniversalis.exception
+
+/**
+ * The world/DC requested is invalid.
+ */
+class InvalidWorldDcException(message: String = "The world/DC requested is invalid"):
+    Throwable(message)

--- a/src/commonMain/kotlin/exception/InvalidWorldDcItemException.kt
+++ b/src/commonMain/kotlin/exception/InvalidWorldDcItemException.kt
@@ -1,0 +1,7 @@
+package cloud.drakon.ktuniversalis.exception
+
+/**
+ * The world/DC or item requested is invalid.
+ */
+class InvalidWorldDcItemException(message: String = "The world/DC or item requested is invalid"):
+    Throwable(message)

--- a/src/commonMain/kotlin/exception/InvalidWorldException.kt
+++ b/src/commonMain/kotlin/exception/InvalidWorldException.kt
@@ -1,0 +1,7 @@
+package cloud.drakon.ktuniversalis.exception
+
+/**
+ * The world requested is invalid.
+ */
+class InvalidWorldException(message: String = "The world requested is invalid"):
+    Throwable(message)

--- a/src/commonMain/kotlin/exception/UniversalisException.kt
+++ b/src/commonMain/kotlin/exception/UniversalisException.kt
@@ -1,0 +1,3 @@
+package cloud.drakon.ktuniversalis.exception
+
+class UniversalisException(message: String = "Unknown error"): Throwable(message)

--- a/src/jsMain/kotlin/KtUniversalisClient.kt
+++ b/src/jsMain/kotlin/KtUniversalisClient.kt
@@ -9,6 +9,7 @@ import cloud.drakon.ktuniversalis.entities.TaxRates
 import cloud.drakon.ktuniversalis.entities.UploadCountHistory
 import cloud.drakon.ktuniversalis.entities.World
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
+import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -101,6 +102,7 @@ import kotlinx.coroutines.promise
      * @param statsWithin The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.
      * @param entriesWithin The amount of time before now to take entries within, in seconds. Negative values will be ignored.
      * @param fields An array of fields that should be included in the response, if omitted will return all fields. For example if you're only interested in the listings price per unit you can set this to listings.pricePerUnit
+     * @throws InvalidParameterException The parameters are invalid
      */
     fun getMarketBoardCurrentData(
         worldDcRegion: String,
@@ -142,7 +144,7 @@ import kotlinx.coroutines.promise
 
         when (marketBoardCurrentData.status.value) {
             200  -> return@promise marketBoardCurrentData.body()
-            400  -> throw Throwable()
+            400  -> throw InvalidParameterException()
             404  -> throw Throwable()
             else -> throw Throwable()
         }

--- a/src/jsMain/kotlin/KtUniversalisClient.kt
+++ b/src/jsMain/kotlin/KtUniversalisClient.kt
@@ -9,6 +9,7 @@ import cloud.drakon.ktuniversalis.entities.TaxRates
 import cloud.drakon.ktuniversalis.entities.UploadCountHistory
 import cloud.drakon.ktuniversalis.entities.World
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
+import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.js.Js
@@ -50,6 +51,7 @@ import kotlinx.coroutines.promise
      * @param world The world to request data for
      * @param dcName The data center to request data for
      * @param entries The number of entries to return (default `50`, max `200`)
+     * @throws InvalidWorldDcException The world/DC requested is invalid
      */
     fun getLeastRecentlyUpdatedItems(
         world: String? = null,
@@ -57,7 +59,7 @@ import kotlinx.coroutines.promise
         entries: Int? = null,
     ): Promise<RecentlyUpdatedItems> = GlobalScope.promise {
         if (world == null && dcName == null) {
-            throw Throwable()
+            throw InvalidWorldDcException()
         }
 
         val leastRecentlyUpdatedItems =
@@ -83,7 +85,7 @@ import kotlinx.coroutines.promise
 
         when (leastRecentlyUpdatedItems.status.value) {
             200  -> return@promise leastRecentlyUpdatedItems.body()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldDcException()
             else -> throw Throwable()
         }
     }
@@ -218,6 +220,7 @@ import kotlinx.coroutines.promise
      * @param world The world to request data for
      * @param dcName The data center to request data for
      * @param entries The number of entries to return (default `50`, max `200`)
+     * @throws InvalidWorldDcException The world/DC requested is invalid
      */
     fun getMostRecentlyUpdatedItems(
         world: String? = null,
@@ -225,7 +228,7 @@ import kotlinx.coroutines.promise
         entries: Int? = null,
     ): Promise<RecentlyUpdatedItems> = GlobalScope.promise {
         if (world == null && dcName == null) {
-            throw Throwable()
+            throw InvalidWorldDcException()
         }
 
         val mostRecentlyUpdatedItems =
@@ -251,7 +254,7 @@ import kotlinx.coroutines.promise
 
         when (mostRecentlyUpdatedItems.status.value) {
             200  -> return@promise mostRecentlyUpdatedItems.body()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldDcException()
             else -> throw Throwable()
         }
     }

--- a/src/jsMain/kotlin/KtUniversalisClient.kt
+++ b/src/jsMain/kotlin/KtUniversalisClient.kt
@@ -12,6 +12,7 @@ import cloud.drakon.ktuniversalis.entities.WorldUploadCount
 import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcItemException
+import cloud.drakon.ktuniversalis.exception.InvalidWorldException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.js.Js
@@ -193,6 +194,7 @@ import kotlinx.coroutines.promise
     /**
      * Returns the current tax rate data for the specified world
      * @param world The world or to retrieve data for. This may be an ID or a name.
+     * @throws InvalidWorldException The world requested is invalid
      */
     fun getMarketTaxRates(world: String): Promise<TaxRates> = GlobalScope.promise {
         val marketBoardTaxRates = ktorClient.get("tax-rates") {
@@ -203,7 +205,7 @@ import kotlinx.coroutines.promise
 
         when (marketBoardTaxRates.status.value) {
             200  -> return@promise marketBoardTaxRates.body()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldException()
             else -> throw Throwable()
         }
     }

--- a/src/jsMain/kotlin/KtUniversalisClient.kt
+++ b/src/jsMain/kotlin/KtUniversalisClient.kt
@@ -9,6 +9,7 @@ import cloud.drakon.ktuniversalis.entities.TaxRates
 import cloud.drakon.ktuniversalis.entities.UploadCountHistory
 import cloud.drakon.ktuniversalis.entities.World
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
+import cloud.drakon.ktuniversalis.exception.InvalidEntriesException
 import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcItemException
@@ -55,6 +56,7 @@ import kotlinx.coroutines.promise
      * @param dcName The data center to request data for
      * @param entries The number of entries to return (default `50`, max `200`)
      * @throws InvalidWorldDcException The world/DC requested is invalid
+     * @throws InvalidEntriesException `entries` must be between `0` and `200`
      */
     fun getLeastRecentlyUpdatedItems(
         world: String? = null,
@@ -76,9 +78,11 @@ import kotlinx.coroutines.promise
                     }
                     if (entries != null) {
                         when {
-                            entries > 200 -> throw Throwable()
-                            entries <= 0  -> throw Throwable()
-                            else          -> parameters.append(
+                            (entries <= 0) || (entries > 200) -> throw InvalidEntriesException(
+                                "`entries` must be between `0` and `200`"
+                            )
+
+                            else                              -> parameters.append(
                                 "entries", entries.toString()
                             )
                         }
@@ -228,6 +232,7 @@ import kotlinx.coroutines.promise
      * @param dcName The data center to request data for
      * @param entries The number of entries to return (default `50`, max `200`)
      * @throws InvalidWorldDcException The world/DC requested is invalid
+     * @throws InvalidEntriesException `entries` must be between `0` and `200`
      */
     fun getMostRecentlyUpdatedItems(
         world: String? = null,
@@ -249,9 +254,11 @@ import kotlinx.coroutines.promise
                     }
                     if (entries != null) {
                         when {
-                            entries > 200 -> throw Throwable()
-                            entries <= 0  -> throw Throwable()
-                            else          -> parameters.append(
+                            (entries <= 0) || (entries > 200) -> throw InvalidEntriesException(
+                                "`entries` must be between `0` and `200`"
+                            )
+
+                            else                              -> parameters.append(
                                 "entries", entries.toString()
                             )
                         }

--- a/src/jsMain/kotlin/KtUniversalisClient.kt
+++ b/src/jsMain/kotlin/KtUniversalisClient.kt
@@ -14,6 +14,7 @@ import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcItemException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldException
+import cloud.drakon.ktuniversalis.exception.UniversalisException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.js.Js
@@ -38,16 +39,30 @@ import kotlinx.coroutines.promise
 
     /**
      * Returns all data centers supported by the Universalis API
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getAvailableDataCenters(): Promise<Array<DataCenter>> = GlobalScope.promise {
-        return@promise ktorClient.get("data-centers").body()
+        val response = ktorClient.get("data-centers")
+
+        if (response.status.value == 200) {
+            return@promise response.body()
+        } else {
+            throw UniversalisException()
+        }
     }
 
     /**
      * Returns the IDs and names of all worlds supported by the Universalis API
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getAvailableWorlds(): Promise<Array<World>> = GlobalScope.promise {
-        return@promise ktorClient.get("worlds").body()
+        val response = ktorClient.get("worlds")
+
+        if (response.status.value == 200) {
+            return@promise response.body()
+        } else {
+            throw UniversalisException()
+        }
     }
 
     /**
@@ -57,6 +72,7 @@ import kotlinx.coroutines.promise
      * @param entries The number of entries to return (default `50`, max `200`)
      * @throws InvalidWorldDcException The world/DC requested is invalid
      * @throws InvalidEntriesException `entries` must be between `0` and `200`
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getLeastRecentlyUpdatedItems(
         world: String? = null,
@@ -93,7 +109,7 @@ import kotlinx.coroutines.promise
         when (leastRecentlyUpdatedItems.status.value) {
             200  -> return@promise leastRecentlyUpdatedItems.body()
             404  -> throw InvalidWorldDcException()
-            else -> throw Throwable()
+            else -> throw UniversalisException()
         }
     }
 
@@ -110,6 +126,7 @@ import kotlinx.coroutines.promise
      * @param fields An array of fields that should be included in the response, if omitted will return all fields. For example if you're only interested in the listings price per unit you can set this to listings.pricePerUnit
      * @throws InvalidParameterException The parameters are invalid
      * @throws InvalidWorldDcItemException The world/DC or item requested is invalid
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getMarketBoardCurrentData(
         worldDcRegion: String,
@@ -153,7 +170,7 @@ import kotlinx.coroutines.promise
             200  -> return@promise marketBoardCurrentData.body()
             400  -> throw InvalidParameterException()
             404  -> throw InvalidWorldDcItemException()
-            else -> throw Throwable()
+            else -> throw UniversalisException()
         }
     }
 
@@ -165,6 +182,7 @@ import kotlinx.coroutines.promise
      * @param statsWithin The amount of time before now to calculate stats over, in milliseconds. By default, this is `7` days.
      * @param entriesWithin The amount of time before now to take entries within, in seconds. Negative values will be ignored.
      * @throws InvalidWorldDcItemException The world/DC or item requested is invalid
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getMarketBoardSaleHistory(
         worldDcRegion: String,
@@ -191,7 +209,7 @@ import kotlinx.coroutines.promise
         when (marketBoardSaleHistory.status.value) {
             200  -> return@promise marketBoardSaleHistory.body()
             404  -> throw InvalidWorldDcItemException()
-            else -> throw Throwable()
+            else -> throw UniversalisException()
         }
     }
 
@@ -199,6 +217,7 @@ import kotlinx.coroutines.promise
      * Returns the current tax rate data for the specified world
      * @param world The world or to retrieve data for. This may be an ID or a name.
      * @throws InvalidWorldException The world requested is invalid
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getMarketTaxRates(world: String): Promise<TaxRates> = GlobalScope.promise {
         val marketBoardTaxRates = ktorClient.get("tax-rates") {
@@ -210,19 +229,20 @@ import kotlinx.coroutines.promise
         when (marketBoardTaxRates.status.value) {
             200  -> return@promise marketBoardTaxRates.body()
             404  -> throw InvalidWorldException()
-            else -> throw Throwable()
+            else -> throw UniversalisException()
         }
     }
 
     /**
      * Returns an array of marketable item IDs
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getMarketableItems(): Promise<IntArray> = GlobalScope.promise {
         val marketableItems = ktorClient.get("marketable")
 
         when (marketableItems.status.value) {
             200  -> return@promise marketableItems.body()
-            else -> throw Throwable()
+            else -> throw UniversalisException()
         }
     }
 
@@ -233,6 +253,7 @@ import kotlinx.coroutines.promise
      * @param entries The number of entries to return (default `50`, max `200`)
      * @throws InvalidWorldDcException The world/DC requested is invalid
      * @throws InvalidEntriesException `entries` must be between `0` and `200`
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getMostRecentlyUpdatedItems(
         world: String? = null,
@@ -269,12 +290,13 @@ import kotlinx.coroutines.promise
         when (mostRecentlyUpdatedItems.status.value) {
             200  -> return@promise mostRecentlyUpdatedItems.body()
             404  -> throw InvalidWorldDcException()
-            else -> throw Throwable()
+            else -> throw UniversalisException()
         }
     }
 
     /**
      * Returns the total upload counts for each client application that uploads data to Universalis
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getUploadCountsByUploadApplication(): Promise<Array<SourceUploadCount>> =
         GlobalScope.promise {
@@ -283,12 +305,13 @@ import kotlinx.coroutines.promise
 
             when (uploadCountsByUploadApplication.status.value) {
                 200  -> return@promise uploadCountsByUploadApplication.body()
-                else -> throw Throwable()
+                else -> throw UniversalisException()
             }
         }
 
     /**
      * Returns the world upload counts and proportions of the total uploads for each world
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getUploadCountsByWorld(): Promise<Map<String, WorldUploadCount>> =
         GlobalScope.promise {
@@ -297,19 +320,20 @@ import kotlinx.coroutines.promise
 
             when (getUploadCountsByWorld.status.value) {
                 200  -> return@promise getUploadCountsByWorld.body()
-                else -> throw Throwable()
+                else -> throw UniversalisException()
             }
         }
 
     /**
      * Returns the number of uploads per day over the past 30 days
+     * @throws UniversalisException The Universalis API returned an unexpected return code
      */
     fun getUploadsPerDay(): Promise<UploadCountHistory> = GlobalScope.promise {
         val getUploadsPerDay = ktorClient.get("extra/stats/upload-history")
 
         when (getUploadsPerDay.status.value) {
             200  -> return@promise getUploadsPerDay.body()
-            else -> throw Throwable()
+            else -> throw UniversalisException()
         }
     }
 }

--- a/src/jsMain/kotlin/KtUniversalisClient.kt
+++ b/src/jsMain/kotlin/KtUniversalisClient.kt
@@ -11,6 +11,7 @@ import cloud.drakon.ktuniversalis.entities.World
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
 import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
+import cloud.drakon.ktuniversalis.exception.InvalidWorldDcItemException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.js.Js
@@ -103,6 +104,7 @@ import kotlinx.coroutines.promise
      * @param entriesWithin The amount of time before now to take entries within, in seconds. Negative values will be ignored.
      * @param fields An array of fields that should be included in the response, if omitted will return all fields. For example if you're only interested in the listings price per unit you can set this to listings.pricePerUnit
      * @throws InvalidParameterException The parameters are invalid
+     * @throws InvalidWorldDcItemException The world/DC or item requested is invalid
      */
     fun getMarketBoardCurrentData(
         worldDcRegion: String,
@@ -145,7 +147,7 @@ import kotlinx.coroutines.promise
         when (marketBoardCurrentData.status.value) {
             200  -> return@promise marketBoardCurrentData.body()
             400  -> throw InvalidParameterException()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldDcItemException()
             else -> throw Throwable()
         }
     }
@@ -157,6 +159,7 @@ import kotlinx.coroutines.promise
      * @param entriesToReturn The number of entries to return. By default, this is set to `1800`, but may be set to a maximum of `999999`.
      * @param statsWithin The amount of time before now to calculate stats over, in milliseconds. By default, this is `7` days.
      * @param entriesWithin The amount of time before now to take entries within, in seconds. Negative values will be ignored.
+     * @throws InvalidWorldDcItemException The world/DC or item requested is invalid
      */
     fun getMarketBoardSaleHistory(
         worldDcRegion: String,
@@ -182,7 +185,7 @@ import kotlinx.coroutines.promise
 
         when (marketBoardSaleHistory.status.value) {
             200  -> return@promise marketBoardSaleHistory.body()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldDcItemException()
             else -> throw Throwable()
         }
     }

--- a/src/jvmMain/kotlin/KtUniversalisClient.kt
+++ b/src/jvmMain/kotlin/KtUniversalisClient.kt
@@ -12,6 +12,7 @@ import cloud.drakon.ktuniversalis.entities.WorldUploadCount
 import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcItemException
+import cloud.drakon.ktuniversalis.exception.InvalidWorldException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.java.Java
@@ -187,6 +188,7 @@ actual object KtUniversalisClient {
     /**
      * Returns the current tax rate data for the specified world
      * @param world The world or to retrieve data for. This may be an ID or a name.
+     * @throws InvalidWorldException The world requested is invalid
      */
     suspend fun getMarketTaxRates(world: String): TaxRates {
         val marketBoardTaxRates = ktorClient.get("tax-rates") {
@@ -197,7 +199,7 @@ actual object KtUniversalisClient {
 
         when (marketBoardTaxRates.status.value) {
             200  -> return marketBoardTaxRates.body()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldException()
             else -> throw Throwable()
         }
     }

--- a/src/jvmMain/kotlin/KtUniversalisClient.kt
+++ b/src/jvmMain/kotlin/KtUniversalisClient.kt
@@ -9,6 +9,7 @@ import cloud.drakon.ktuniversalis.entities.TaxRates
 import cloud.drakon.ktuniversalis.entities.UploadCountHistory
 import cloud.drakon.ktuniversalis.entities.World
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
+import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -95,6 +96,7 @@ actual object KtUniversalisClient {
      * @param statsWithin The amount of time before now to calculate stats over, in milliseconds. By default, this is 7 days.
      * @param entriesWithin The amount of time before now to take entries within, in seconds. Negative values will be ignored.
      * @param fields An array of fields that should be included in the response, if omitted will return all fields. For example if you're only interested in the listings price per unit you can set this to listings.pricePerUnit
+     * @throws InvalidParameterException The parameters are invalid
      */
     suspend fun getMarketBoardCurrentData(
         worldDcRegion: String,
@@ -136,7 +138,7 @@ actual object KtUniversalisClient {
 
         when (marketBoardCurrentData.status.value) {
             200  -> return marketBoardCurrentData.body()
-            400  -> throw Throwable()
+            400  -> throw InvalidParameterException()
             404  -> throw Throwable()
             else -> throw Throwable()
         }

--- a/src/jvmMain/kotlin/KtUniversalisClient.kt
+++ b/src/jvmMain/kotlin/KtUniversalisClient.kt
@@ -9,6 +9,7 @@ import cloud.drakon.ktuniversalis.entities.TaxRates
 import cloud.drakon.ktuniversalis.entities.UploadCountHistory
 import cloud.drakon.ktuniversalis.entities.World
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
+import cloud.drakon.ktuniversalis.exception.InvalidEntriesException
 import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcItemException
@@ -49,6 +50,7 @@ actual object KtUniversalisClient {
      * @param dcName The data center to request data for
      * @param entries The number of entries to return (default `50`, max `200`)
      * @throws InvalidWorldDcException The world/DC requested is invalid
+     * @throws InvalidEntriesException `entries` must be between `0` and `200`
      */
     suspend fun getLeastRecentlyUpdatedItems(
         world: String? = null,
@@ -70,9 +72,11 @@ actual object KtUniversalisClient {
                     }
                     if (entries != null) {
                         when {
-                            entries > 200 -> throw Throwable()
-                            entries <= 0  -> throw Throwable()
-                            else          -> parameters.append(
+                            (entries <= 0) || (entries > 200) -> throw InvalidEntriesException(
+                                "`entries` must be between `0` and `200`"
+                            )
+
+                            else                              -> parameters.append(
                                 "entries", entries.toString()
                             )
                         }
@@ -222,6 +226,7 @@ actual object KtUniversalisClient {
      * @param dcName The data center to request data for
      * @param entries The number of entries to return (default `50`, max `200`)
      * @throws InvalidWorldDcException The world/DC requested is invalid
+     * @throws InvalidEntriesException `entries` must be between `0` and `200`
      */
     suspend fun getMostRecentlyUpdatedItems(
         world: String? = null,
@@ -243,9 +248,11 @@ actual object KtUniversalisClient {
                     }
                     if (entries != null) {
                         when {
-                            entries > 200 -> throw Throwable()
-                            entries <= 0  -> throw Throwable()
-                            else          -> parameters.append(
+                            entries <= 0 || entries > 200 -> throw InvalidEntriesException(
+                                "`entries` must be between `0` and `200`"
+                            )
+
+                            else                          -> parameters.append(
                                 "entries", entries.toString()
                             )
                         }

--- a/src/jvmMain/kotlin/KtUniversalisClient.kt
+++ b/src/jvmMain/kotlin/KtUniversalisClient.kt
@@ -9,6 +9,7 @@ import cloud.drakon.ktuniversalis.entities.TaxRates
 import cloud.drakon.ktuniversalis.entities.UploadCountHistory
 import cloud.drakon.ktuniversalis.entities.World
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
+import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.java.Java
@@ -44,6 +45,7 @@ actual object KtUniversalisClient {
      * @param world The world to request data for
      * @param dcName The data center to request data for
      * @param entries The number of entries to return (default `50`, max `200`)
+     * @throws InvalidWorldDcException The world/DC requested is invalid
      */
     suspend fun getLeastRecentlyUpdatedItems(
         world: String? = null,
@@ -51,7 +53,7 @@ actual object KtUniversalisClient {
         entries: Int? = null,
     ): RecentlyUpdatedItems {
         if (world == null && dcName == null) {
-            throw Throwable()
+            throw InvalidWorldDcException()
         }
 
         val leastRecentlyUpdatedItems =
@@ -77,7 +79,7 @@ actual object KtUniversalisClient {
 
         when (leastRecentlyUpdatedItems.status.value) {
             200  -> return leastRecentlyUpdatedItems.body()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldDcException()
             else -> throw Throwable()
         }
     }
@@ -212,6 +214,7 @@ actual object KtUniversalisClient {
      * @param world The world to request data for
      * @param dcName The data center to request data for
      * @param entries The number of entries to return (default `50`, max `200`)
+     * @throws InvalidWorldDcException The world/DC requested is invalid
      */
     suspend fun getMostRecentlyUpdatedItems(
         world: String? = null,
@@ -219,7 +222,7 @@ actual object KtUniversalisClient {
         entries: Int? = null,
     ): RecentlyUpdatedItems {
         if (world == null && dcName == null) {
-            throw Throwable()
+            throw InvalidWorldDcException()
         }
 
         val mostRecentlyUpdatedItems =
@@ -245,7 +248,7 @@ actual object KtUniversalisClient {
 
         when (mostRecentlyUpdatedItems.status.value) {
             200  -> return mostRecentlyUpdatedItems.body()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldDcException()
             else -> throw Throwable()
         }
     }

--- a/src/jvmMain/kotlin/KtUniversalisClient.kt
+++ b/src/jvmMain/kotlin/KtUniversalisClient.kt
@@ -11,6 +11,7 @@ import cloud.drakon.ktuniversalis.entities.World
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
 import cloud.drakon.ktuniversalis.exception.InvalidParameterException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDcException
+import cloud.drakon.ktuniversalis.exception.InvalidWorldDcItemException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.java.Java
@@ -97,6 +98,7 @@ actual object KtUniversalisClient {
      * @param entriesWithin The amount of time before now to take entries within, in seconds. Negative values will be ignored.
      * @param fields An array of fields that should be included in the response, if omitted will return all fields. For example if you're only interested in the listings price per unit you can set this to listings.pricePerUnit
      * @throws InvalidParameterException The parameters are invalid
+     * @throws InvalidWorldDcItemException The world/DC or item requested is invalid
      */
     suspend fun getMarketBoardCurrentData(
         worldDcRegion: String,
@@ -139,7 +141,7 @@ actual object KtUniversalisClient {
         when (marketBoardCurrentData.status.value) {
             200  -> return marketBoardCurrentData.body()
             400  -> throw InvalidParameterException()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldDcItemException()
             else -> throw Throwable()
         }
     }
@@ -151,6 +153,7 @@ actual object KtUniversalisClient {
      * @param entriesToReturn The number of entries to return. By default, this is set to `1800`, but may be set to a maximum of `999999`.
      * @param statsWithin The amount of time before now to calculate stats over, in milliseconds. By default, this is `7` days.
      * @param entriesWithin The amount of time before now to take entries within, in seconds. Negative values will be ignored.
+     * @throws InvalidWorldDcItemException The world/DC or item requested is invalid
      */
     suspend fun getMarketBoardSaleHistory(
         worldDcRegion: String,
@@ -176,7 +179,7 @@ actual object KtUniversalisClient {
 
         when (marketBoardSaleHistory.status.value) {
             200  -> return marketBoardSaleHistory.body()
-            404  -> throw Throwable()
+            404  -> throw InvalidWorldDcItemException()
             else -> throw Throwable()
         }
     }


### PR DESCRIPTION
The Universalis API will sometimes return non-200 error codes. This PR adds the following exceptions when an appropriate error code is returned by an endpoint:
- `InvalidEntriesException` (The `entries` field contain a value less than `0` or greater than `200`
- `InvalidParameterException` (The parameters were invalid)
- `InvalidWorldDcItemException` (The world/DC or item requested is invalid)
- `InvalidWorldDcException` (The world/DC requested is invalid)
- `InvalidWorldException` (The world requested is invalid)
- `UniversalisException` (The Universalis API returned an unexpected status code)