### PR TITLE
Refactor private functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Kotlin](https://img.shields.io/badge/kotlin-1.9.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![License](https://img.shields.io/github/license/drakon64/KtUniversalis)](https://opensource.org/license/mit/)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=KtUniversalis&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=KtUniversalis)
-[![KDoc](https://javadoc.io/badge2/cloud.drakon/ktuniversalis/6.0.0/KDoc.svg)](https://javadoc.io/doc/cloud.drakon/ktuniversalis/6.0.0)
+[![KDoc](https://javadoc.io/badge2/cloud.drakon/ktuniversalis/6.0.0.1-SNAPSHOT/KDoc.svg)](https://javadoc.io/doc/cloud.drakon/ktuniversalis/6.0.0.1-SNAPSHOT)
 
 KtUniversalis is a Kotlin Multiplatform and JavaScript/TypeScript library for the [Universalis](https://universalis.app) REST API.
 
@@ -17,7 +17,7 @@ Add the following to your `build.gradle.kts` file to install KtUniversalis:
 
 ```kotlin
 dependencies {
-    implementation("cloud.drakon:ktuniversalis:6.0.0")
+    implementation("cloud.drakon:ktuniversalis:6.0.0.1-SNAPSHOT")
 }
 ```
 
@@ -26,7 +26,7 @@ dependencies {
 #### `package.json`
 
 ```json
-"ktuniversalis": "6.0.0"
+"ktuniversalis": "6.0.0.1-SNAPSHOT"
 ```
 
 #### Command line

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Kotlin](https://img.shields.io/badge/kotlin-1.9.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![License](https://img.shields.io/github/license/drakon64/KtUniversalis)](https://opensource.org/license/mit/)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=KtUniversalis&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=KtUniversalis)
-[![KDoc](https://javadoc.io/badge2/cloud.drakon/ktuniversalis/6.0.0.1-SNAPSHOT/KDoc.svg)](https://javadoc.io/doc/cloud.drakon/ktuniversalis/6.0.0.1-SNAPSHOT)
+[![KDoc](https://javadoc.io/badge2/cloud.drakon/ktuniversalis/6.0.1-SNAPSHOT/KDoc.svg)](https://javadoc.io/doc/cloud.drakon/ktuniversalis/6.0.1-SNAPSHOT)
 
 KtUniversalis is a Kotlin Multiplatform and JavaScript/TypeScript library for the [Universalis](https://universalis.app) REST API.
 
@@ -17,7 +17,7 @@ Add the following to your `build.gradle.kts` file to install KtUniversalis:
 
 ```kotlin
 dependencies {
-    implementation("cloud.drakon:ktuniversalis:6.0.0.1-SNAPSHOT")
+    implementation("cloud.drakon:ktuniversalis:6.0.1-SNAPSHOT")
 }
 ```
 
@@ -26,7 +26,7 @@ dependencies {
 #### `package.json`
 
 ```json
-"ktuniversalis": "6.0.0.1-SNAPSHOT"
+"ktuniversalis": "6.0.1-SNAPSHOT"
 ```
 
 #### Command line

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 group = "cloud.drakon"
-version = "6.0.0"
+version = "6.0.0.1-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 group = "cloud.drakon"
-version = "6.0.0.1-SNAPSHOT"
+version = "6.0.1-SNAPSHOT"
 
 repositories {
     mavenCentral()

--- a/src/commonMain/kotlin/GetMarketBoardCurrentData.kt
+++ b/src/commonMain/kotlin/GetMarketBoardCurrentData.kt
@@ -12,7 +12,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 
-private suspend fun getMarketBoardCurrentDataList(
+internal suspend fun getMarketBoardCurrentDataList(
     worldDcRegion: String,
     itemIds: List<Int>,
     listings: Int? = null,

--- a/src/commonMain/kotlin/GetMarketBoardSaleHistory.kt
+++ b/src/commonMain/kotlin/GetMarketBoardSaleHistory.kt
@@ -11,7 +11,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.statement.HttpResponse
 
-private suspend fun getMarketBoardSaleHistoryList(
+internal suspend fun getMarketBoardSaleHistoryList(
     worldDcRegion: String,
     itemIds: List<Int>,
     entriesToReturn: Int? = null,

--- a/src/commonMain/kotlin/GetRecentlyUpdatedItems.kt
+++ b/src/commonMain/kotlin/GetRecentlyUpdatedItems.kt
@@ -8,7 +8,7 @@ import cloud.drakon.ktuniversalis.world.World
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 
-private suspend fun getRecentlyUpdatedItems(
+internal suspend fun getRecentlyUpdatedItems(
     world: World? = null,
     dcName: DataCenter? = null,
     entries: Short? = null,

--- a/src/commonMain/kotlin/world/DataCenter.kt
+++ b/src/commonMain/kotlin/world/DataCenter.kt
@@ -4,8 +4,9 @@ package cloud.drakon.ktuniversalis.world
 
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
-@JsExport enum class DataCenter {
+@JsExport @Serializable enum class DataCenter {
     Elemental,
     Gaia,
     Mana,

--- a/src/commonMain/kotlin/world/Region.kt
+++ b/src/commonMain/kotlin/world/Region.kt
@@ -4,7 +4,8 @@ package cloud.drakon.ktuniversalis.world
 
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
-@JsExport enum class Region {
+@JsExport @Serializable enum class Region {
     Japan, Europe, NorthAmerica, Oceania, China, 中国
 }

--- a/src/commonMain/kotlin/world/World.kt
+++ b/src/commonMain/kotlin/world/World.kt
@@ -4,8 +4,9 @@ package cloud.drakon.ktuniversalis.world
 
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
+import kotlinx.serialization.Serializable
 
-@JsExport enum class World {
+@JsExport @Serializable enum class World {
     Ravana,
     Bismarck,
     Asura,

--- a/src/jsMain/kotlin/GetMarketBoardCurrentData.js.kt
+++ b/src/jsMain/kotlin/GetMarketBoardCurrentData.js.kt
@@ -2,12 +2,16 @@
 
 package cloud.drakon.ktuniversalis
 
+import cloud.drakon.ktuniversalis.entities.CurrentlyShown
+import cloud.drakon.ktuniversalis.entities.Multi
 import cloud.drakon.ktuniversalis.exception.InvalidParametersException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDataCenterItemException
 import cloud.drakon.ktuniversalis.exception.UniversalisException
 import cloud.drakon.ktuniversalis.world.DataCenter
 import cloud.drakon.ktuniversalis.world.Region
 import cloud.drakon.ktuniversalis.world.World
+import io.ktor.client.call.body
+import kotlin.js.Promise
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.promise
@@ -36,17 +40,17 @@ fun getMarketBoardCurrentDataAsync(
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardCurrentData(
-        world,
-        itemId,
+): Promise<CurrentlyShown> = GlobalScope.promise {
+    getMarketBoardCurrentDataList(
+        world.name,
+        listOf(itemId),
         listings,
         entries,
         noGst,
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -73,17 +77,17 @@ fun getMarketBoardCurrentDataAsync(
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardCurrentData(
-        dcName,
-        itemId,
+): Promise<CurrentlyShown> = GlobalScope.promise {
+    getMarketBoardCurrentDataList(
+        dcName.name,
+        listOf(itemId),
         listings,
         entries,
         noGst,
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -110,17 +114,17 @@ fun getMarketBoardCurrentDataAsync(
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardCurrentData(
-        region,
-        itemId,
+): Promise<CurrentlyShown> = GlobalScope.promise {
+    getMarketBoardCurrentDataList(
+        region.name,
+        listOf(itemId),
         listings,
         entries,
         noGst,
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -147,9 +151,9 @@ fun getMarketBoardCurrentDataAsync(
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardCurrentData(
-        world,
+): Promise<Multi<CurrentlyShown>> = GlobalScope.promise {
+    getMarketBoardCurrentDataList(
+        world.name,
         itemIds.toList(),
         listings,
         entries,
@@ -157,7 +161,7 @@ fun getMarketBoardCurrentDataAsync(
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -184,9 +188,9 @@ fun getMarketBoardCurrentDataAsync(
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardCurrentData(
-        dcName,
+): Promise<Multi<CurrentlyShown>> = GlobalScope.promise {
+    getMarketBoardCurrentDataList(
+        dcName.name,
         itemIds.toList(),
         listings,
         entries,
@@ -194,7 +198,7 @@ fun getMarketBoardCurrentDataAsync(
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -221,9 +225,9 @@ fun getMarketBoardCurrentDataAsync(
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardCurrentData(
-        region,
+): Promise<Multi<CurrentlyShown>> = GlobalScope.promise {
+    getMarketBoardCurrentDataList(
+        region.name,
         itemIds.toList(),
         listings,
         entries,
@@ -231,5 +235,5 @@ fun getMarketBoardCurrentDataAsync(
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }

--- a/src/jsMain/kotlin/GetMarketBoardSaleHistory.js.kt
+++ b/src/jsMain/kotlin/GetMarketBoardSaleHistory.js.kt
@@ -2,11 +2,15 @@
 
 package cloud.drakon.ktuniversalis
 
+import cloud.drakon.ktuniversalis.entities.History
+import cloud.drakon.ktuniversalis.entities.Multi
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDataCenterItemException
 import cloud.drakon.ktuniversalis.exception.UniversalisException
 import cloud.drakon.ktuniversalis.world.DataCenter
 import cloud.drakon.ktuniversalis.world.Region
 import cloud.drakon.ktuniversalis.world.World
+import io.ktor.client.call.body
+import kotlin.js.Promise
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.promise
@@ -28,10 +32,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardSaleHistory(
-        world, itemId, entriesToReturn, statsWithin, entriesWithin
-    )
+): Promise<History> = GlobalScope.promise {
+    getMarketBoardSaleHistoryList(
+        world.name, listOf(itemId), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -51,10 +55,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardSaleHistory(
-        dcName, itemId, entriesToReturn, statsWithin, entriesWithin
-    )
+): Promise<History> = GlobalScope.promise {
+    getMarketBoardSaleHistoryList(
+        dcName.name, listOf(itemId), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -74,10 +78,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardSaleHistory(
-        region, itemId, entriesToReturn, statsWithin, entriesWithin
-    )
+): Promise<History> = GlobalScope.promise {
+    getMarketBoardSaleHistoryList(
+        region.name, listOf(itemId), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -97,10 +101,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardSaleHistory(
-        world, itemIds.toList(), entriesToReturn, statsWithin, entriesWithin
-    )
+): Promise<Multi<History>> = GlobalScope.promise {
+    getMarketBoardSaleHistoryList(
+        world.name, itemIds.toList(), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -120,10 +124,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardSaleHistory(
-        dcName, itemIds.toList(), entriesToReturn, statsWithin, entriesWithin
-    )
+): Promise<Multi<History>> = GlobalScope.promise {
+    getMarketBoardSaleHistoryList(
+        dcName.name, itemIds.toList(), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -143,8 +147,8 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.promise {
-    getMarketBoardSaleHistory(
-        region, itemIds.toList(), entriesToReturn, statsWithin, entriesWithin
-    )
+): Promise<Multi<History>> = GlobalScope.promise {
+    getMarketBoardSaleHistoryList(
+        region.name, itemIds.toList(), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }

--- a/src/jsMain/kotlin/GetRecentlyUpdatedItems.js.kt
+++ b/src/jsMain/kotlin/GetRecentlyUpdatedItems.js.kt
@@ -22,7 +22,7 @@ fun getLeastRecentlyUpdatedItemsAsync(
     world: World,
     entries: Short? = null,
 ) = GlobalScope.promise {
-    getLeastRecentlyUpdatedItems(world, entries)
+    getRecentlyUpdatedItems(world, null, entries, true)
 }
 
 /**
@@ -37,7 +37,7 @@ fun getLeastRecentlyUpdatedItemsAsync(
     dcName: DataCenter,
     entries: Short? = null,
 ) = GlobalScope.promise {
-    getLeastRecentlyUpdatedItems(dcName, entries)
+    getRecentlyUpdatedItems(null, dcName, entries, true)
 }
 
 /**
@@ -52,7 +52,7 @@ fun getMostRecentlyUpdatedItemsAsync(
     world: World,
     entries: Short? = null,
 ) = GlobalScope.promise {
-    getMostRecentlyUpdatedItems(world, entries)
+    getRecentlyUpdatedItems(world, null, entries, false)
 }
 
 /**
@@ -67,5 +67,5 @@ fun getMostRecentlyUpdatedItemsAsync(
     dcName: DataCenter,
     entries: Short? = null,
 ) = GlobalScope.promise {
-    getMostRecentlyUpdatedItems(dcName, entries)
+    getRecentlyUpdatedItems(null, dcName, entries, false)
 }

--- a/src/jvmMain/kotlin/GetMarketBoardCurrentData.jvm.kt
+++ b/src/jvmMain/kotlin/GetMarketBoardCurrentData.jvm.kt
@@ -2,12 +2,15 @@
 
 package cloud.drakon.ktuniversalis
 
+import cloud.drakon.ktuniversalis.entities.CurrentlyShown
 import cloud.drakon.ktuniversalis.exception.InvalidParametersException
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDataCenterItemException
 import cloud.drakon.ktuniversalis.exception.UniversalisException
 import cloud.drakon.ktuniversalis.world.DataCenter
 import cloud.drakon.ktuniversalis.world.Region
 import cloud.drakon.ktuniversalis.world.World
+import io.ktor.client.call.body
+import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
@@ -39,17 +42,17 @@ import kotlinx.coroutines.future.future
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardCurrentData(
-        world,
-        itemId,
+): CompletableFuture<CurrentlyShown> = GlobalScope.future {
+    getMarketBoardCurrentDataList(
+        world.name,
+        listOf(itemId),
         listings,
         entries,
         noGst,
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -79,17 +82,17 @@ import kotlinx.coroutines.future.future
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardCurrentData(
-        dcName,
-        itemId,
+): CompletableFuture<CurrentlyShown> = GlobalScope.future {
+    getMarketBoardCurrentDataList(
+        dcName.name,
+        listOf(itemId),
         listings,
         entries,
         noGst,
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -119,17 +122,17 @@ import kotlinx.coroutines.future.future
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardCurrentData(
-        region,
-        itemId,
+): CompletableFuture<CurrentlyShown> = GlobalScope.future {
+    getMarketBoardCurrentDataList(
+        region.name,
+        listOf(itemId),
         listings,
         entries,
         noGst,
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -159,9 +162,9 @@ import kotlinx.coroutines.future.future
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardCurrentData(
-        world,
+): CompletableFuture<CurrentlyShown> = GlobalScope.future {
+    getMarketBoardCurrentDataList(
+        world.name,
         itemIds,
         listings,
         entries,
@@ -169,7 +172,7 @@ import kotlinx.coroutines.future.future
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -199,9 +202,9 @@ import kotlinx.coroutines.future.future
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardCurrentData(
-        dcName,
+): CompletableFuture<CurrentlyShown> = GlobalScope.future {
+    getMarketBoardCurrentDataList(
+        dcName.name,
         itemIds,
         listings,
         entries,
@@ -209,7 +212,7 @@ import kotlinx.coroutines.future.future
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }
 
 /**
@@ -226,8 +229,7 @@ import kotlinx.coroutines.future.future
  * @throws InvalidWorldDataCenterItemException The world/DC or item requested is invalid.
  * @throws UniversalisException The Universalis API returned an unexpected return code.
  */
-@JvmOverloads
-@Throws(
+@JvmOverloads @Throws(
     InvalidParametersException::class,
     InvalidWorldDataCenterItemException::class,
     UniversalisException::class
@@ -240,9 +242,9 @@ import kotlinx.coroutines.future.future
     hq: Boolean? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardCurrentData(
-        region,
+): CompletableFuture<CurrentlyShown> = GlobalScope.future {
+    getMarketBoardCurrentDataList(
+        region.name,
         itemIds,
         listings,
         entries,
@@ -250,5 +252,5 @@ import kotlinx.coroutines.future.future
         hq,
         statsWithin,
         entriesWithin,
-    )
+    ).body()
 }

--- a/src/jvmMain/kotlin/GetMarketBoardSaleHistory.jvm.kt
+++ b/src/jvmMain/kotlin/GetMarketBoardSaleHistory.jvm.kt
@@ -2,11 +2,14 @@
 
 package cloud.drakon.ktuniversalis
 
+import cloud.drakon.ktuniversalis.entities.History
 import cloud.drakon.ktuniversalis.exception.InvalidWorldDataCenterItemException
 import cloud.drakon.ktuniversalis.exception.UniversalisException
 import cloud.drakon.ktuniversalis.world.DataCenter
 import cloud.drakon.ktuniversalis.world.Region
 import cloud.drakon.ktuniversalis.world.World
+import io.ktor.client.call.body
+import java.util.concurrent.CompletableFuture
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
@@ -29,10 +32,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardSaleHistory(
-        world, itemId, entriesToReturn, statsWithin, entriesWithin
-    )
+): CompletableFuture<History> = GlobalScope.future {
+    getMarketBoardSaleHistoryList(
+        world.name, listOf(itemId), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -53,10 +56,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardSaleHistory(
-        dcName, itemId, entriesToReturn, statsWithin, entriesWithin
-    )
+): CompletableFuture<History> = GlobalScope.future {
+    getMarketBoardSaleHistoryList(
+        dcName.name, listOf(itemId), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -77,10 +80,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardSaleHistory(
-        region, itemId, entriesToReturn, statsWithin, entriesWithin
-    )
+): CompletableFuture<History> = GlobalScope.future {
+    getMarketBoardSaleHistoryList(
+        region.name, listOf(itemId), entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -101,10 +104,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardSaleHistory(
-        world, itemIds, entriesToReturn, statsWithin, entriesWithin
-    )
+): CompletableFuture<History> = GlobalScope.future {
+    getMarketBoardSaleHistoryList(
+        world.name, itemIds, entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -125,10 +128,10 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardSaleHistory(
-        dcName, itemIds, entriesToReturn, statsWithin, entriesWithin
-    )
+): CompletableFuture<History> = GlobalScope.future {
+    getMarketBoardSaleHistoryList(
+        dcName.name, itemIds, entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }
 
 /**
@@ -149,8 +152,8 @@ fun getMarketBoardSaleHistoryAsync(
     entriesToReturn: Int? = null,
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
-) = GlobalScope.future {
-    getMarketBoardSaleHistory(
-        region, itemIds, entriesToReturn, statsWithin, entriesWithin
-    )
+): CompletableFuture<History> = GlobalScope.future {
+    getMarketBoardSaleHistoryList(
+        region.name, itemIds, entriesToReturn, statsWithin, entriesWithin
+    ).body()
 }

--- a/src/jvmMain/kotlin/GetRecentlyUpdatedItems.jvm.kt
+++ b/src/jvmMain/kotlin/GetRecentlyUpdatedItems.jvm.kt
@@ -23,7 +23,7 @@ fun getLeastRecentlyUpdatedItemsAsync(
     world: World,
     entries: Short? = null,
 ) = GlobalScope.future {
-    getLeastRecentlyUpdatedItems(world, entries)
+    getRecentlyUpdatedItems(world, null, entries, true)
 }
 
 /**
@@ -39,7 +39,7 @@ fun getLeastRecentlyUpdatedItemsAsync(
     dcName: DataCenter,
     entries: Short? = null,
 ) = GlobalScope.future {
-    getLeastRecentlyUpdatedItems(dcName, entries)
+    getRecentlyUpdatedItems(null, dcName, entries, true)
 }
 
 /**
@@ -55,7 +55,7 @@ fun getMostRecentlyUpdatedItemsAsync(
     world: World,
     entries: Short? = null,
 ) = GlobalScope.future {
-    getMostRecentlyUpdatedItems(world, entries)
+    getRecentlyUpdatedItems(world, null, entries, false)
 }
 
 /**
@@ -71,5 +71,5 @@ fun getMostRecentlyUpdatedItemsAsync(
     dcName: DataCenter,
     entries: Short? = null,
 ) = GlobalScope.future {
-    getMostRecentlyUpdatedItems(dcName, entries)
+    getRecentlyUpdatedItems(null, dcName, entries, false)
 }


### PR DESCRIPTION
- Make some JavaScript functions more efficient
  - This also removes some non-exported functions, making the code smaller
- Make some non-Kotlin JVM functions more efficient
- Add a serialiser for enum classes
  - On JavaScript and Kotlin/JS, this should fix the `JsonConvertException` error thrown by `getUploadCountsByWorld()`/`getUploadCountsByWorldAsync()`