### PR TITLE
Rename `SupportedWorld`/`SupportedDataCenter` classes

### DIFF
--- a/src/commonMain/kotlin/KtUniversalis.kt
+++ b/src/commonMain/kotlin/KtUniversalis.kt
@@ -1,8 +1,8 @@
 package cloud.drakon.ktuniversalis
 
+import cloud.drakon.ktuniversalis.entities.AvailableDataCenter
+import cloud.drakon.ktuniversalis.entities.AvailableWorld
 import cloud.drakon.ktuniversalis.entities.SourceUploadCount
-import cloud.drakon.ktuniversalis.entities.SupportedDataCenter
-import cloud.drakon.ktuniversalis.entities.SupportedWorld
 import cloud.drakon.ktuniversalis.entities.TaxRates
 import cloud.drakon.ktuniversalis.entities.UploadCountHistory
 import cloud.drakon.ktuniversalis.entities.WorldUploadCount
@@ -34,7 +34,7 @@ internal val ktorClient = HttpClient {
  * @throws UniversalisException The Universalis API returned an unexpected return code.
  */
 @JsName("getAvailableDataCentersSuspend")
-suspend fun getAvailableDataCenters(): List<SupportedDataCenter> = ktorClient.get(
+suspend fun getAvailableDataCenters(): List<AvailableDataCenter> = ktorClient.get(
     "data-centers"
 ).let {
     when (it.status.value) {
@@ -48,7 +48,7 @@ suspend fun getAvailableDataCenters(): List<SupportedDataCenter> = ktorClient.ge
  * @throws UniversalisException The Universalis API returned an unexpected return code.
  */
 @JsName("getAvailableWorldsSuspend")
-suspend fun getAvailableWorlds(): List<SupportedWorld> = ktorClient.get("worlds").let {
+suspend fun getAvailableWorlds(): List<AvailableWorld> = ktorClient.get("worlds").let {
     when (it.status.value) {
         200  -> return it.body()
         else -> throw throwUniversalisException(it)

--- a/src/commonMain/kotlin/entities/AvailableDataCenter.kt
+++ b/src/commonMain/kotlin/entities/AvailableDataCenter.kt
@@ -14,7 +14,7 @@ import kotlinx.serialization.Serializable
  * @property worlds World IDs of a data center supported by the Universalis API
  */
 @JsExport @Serializable data class AvailableDataCenter(
-    val name: DataCenter? = null,
-    val region: String? = null,
-    val worlds: List<Short>? = null,
+    val name: DataCenter,
+    val region: String,
+    val worlds: List<Short>,
 )

--- a/src/commonMain/kotlin/entities/AvailableDataCenter.kt
+++ b/src/commonMain/kotlin/entities/AvailableDataCenter.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.Serializable
  * @property region Region of a data center supported by the Universalis API
  * @property worlds World IDs of a data center supported by the Universalis API
  */
-@JsExport @Serializable data class SupportedDataCenter(
+@JsExport @Serializable data class AvailableDataCenter(
     val name: DataCenter? = null,
     val region: String? = null,
     val worlds: List<Short>? = null,

--- a/src/commonMain/kotlin/entities/AvailableWorld.kt
+++ b/src/commonMain/kotlin/entities/AvailableWorld.kt
@@ -12,4 +12,4 @@ import kotlinx.serialization.Serializable
  * @property id ID of a world supported by the Universalis API
  * @property name Name of a world supported by the Universalis API
  */
-@JsExport @Serializable data class SupportedWorld(val id: Int, val name: World)
+@JsExport @Serializable data class AvailableWorld(val id: Int, val name: World)


### PR DESCRIPTION
- Rename the `SupportedWorld`/`SupportedDataCenter` classes to `AvailableWorld`/`AvailableDatacenter`
  - This brings the class names in line with the functions that return them
- Remove nullable parameters from `AvailableDataCenter`