### PR TITLE
Add a type alias for `stackSizeHistogram` properties

### DIFF
--- a/src/commonMain/kotlin/entities/CurrentlyShown.kt
+++ b/src/commonMain/kotlin/entities/CurrentlyShown.kt
@@ -65,13 +65,13 @@ import kotlinx.serialization.Serializable
     val maxPrice: Int,
     @SerialName("maxPriceNQ") val maxPriceNq: Int,
     @SerialName("maxPriceHQ") val maxPriceHq: Int,
-    val stackSizeHistogram: Map<String, Int>? = null,
+    val stackSizeHistogram: StackSizeHistogram = null,
 
     @SerialName("stackSizeHistogramNQ")
-    val stackSizeHistogramNq: Map<String, Int>? = null,
+    val stackSizeHistogramNq: StackSizeHistogram = null,
 
     @SerialName("stackSizeHistogramHQ")
-    val stackSizeHistogramHq: Map<String, Int>? = null,
+    val stackSizeHistogramHq: StackSizeHistogram = null,
 
     val worldName: World? = null,
     val worldUploadTimes: Map<String, Long>? = null,

--- a/src/commonMain/kotlin/entities/History.kt
+++ b/src/commonMain/kotlin/entities/History.kt
@@ -31,13 +31,13 @@ import kotlinx.serialization.Serializable
     val entries: List<MinimizedSale>? = null,
     val dcName: DataCenter? = null,
     val regionName: String? = null,
-    val stackSizeHistogram: Map<String, Int>? = null,
+    val stackSizeHistogram: StackSizeHistogram = null,
 
     @SerialName("stackSizeHistogramNQ")
-    val stackSizeHistogramNq: Map<String, Int>? = null,
+    val stackSizeHistogramNq: StackSizeHistogram = null,
 
     @SerialName("stackSizeHistogramHQ")
-    val stackSizeHistogramHq: Map<String, Int>? = null,
+    val stackSizeHistogramHq: StackSizeHistogram = null,
 
     val regularSaleVelocity: Double,
     val nqSaleVelocity: Double,

--- a/src/commonMain/kotlin/entities/StackSizeHistogram.kt
+++ b/src/commonMain/kotlin/entities/StackSizeHistogram.kt
@@ -1,0 +1,6 @@
+package cloud.drakon.ktuniversalis.entities
+
+/**
+ * A [Map] of quantities to listing counts, representing the number of listings of each quantity.
+ */
+typealias StackSizeHistogram = Map<String, Int>?

--- a/src/commonMain/kotlin/entities/StackSizeHistogram.kt
+++ b/src/commonMain/kotlin/entities/StackSizeHistogram.kt
@@ -3,4 +3,4 @@ package cloud.drakon.ktuniversalis.entities
 /**
  * A [Map] of quantities to listing counts, representing the number of listings of each quantity.
  */
-typealias StackSizeHistogram = Map<String, Int>?
+typealias StackSizeHistogram = Map<Byte, Int>?


### PR DESCRIPTION
- Add a type alias for `stackSizeHistogram` properties
- Change `stackSizeHistogram` to be `Map<Byte, Int>?`