### PR TITLE
Remove redundant class properties

### DIFF
--- a/src/commonMain/kotlin/entities/CurrentlyShown.kt
+++ b/src/commonMain/kotlin/entities/CurrentlyShown.kt
@@ -2,7 +2,6 @@
 
 package cloud.drakon.ktuniversalis.entities
 
-import cloud.drakon.ktuniversalis.world.DataCenter
 import cloud.drakon.ktuniversalis.world.World
 import cloud.drakon.ktuniversalis.world.idToWorld
 import kotlin.js.ExperimentalJsExport
@@ -11,13 +10,9 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * @property itemId The item ID
- * @property worldId The world ID, if applicable
  * @property lastUploadTime The last upload time for this endpoint, in milliseconds since the UNIX epoch
  * @property listings The currently-shown listings
  * @property recentHistory The currently-shown sales
- * @property dcName The DC name, if applicable
- * @property regionName The region name, if applicable
  * @property currentAveragePrice The average listing price, with outliers removed beyond 3 standard deviations of the mean
  * @property currentAveragePriceNq The average NQ listing price, with outliers removed beyond 3 standard deviations of the mean
  * @property currentAveragePriceHq The average HQ listing price, with outliers removed beyond 3 standard deviations of the mean
@@ -36,7 +31,6 @@ import kotlinx.serialization.Serializable
  * @property stackSizeHistogram A map of quantities to listing counts, representing the number of listings of each quantity
  * @property stackSizeHistogramNq A map of quantities to NQ listing counts, representing the number of listings of each quantity
  * @property stackSizeHistogramHq A map of quantities to HQ listing counts, representing the number of listings of each quantity
- * @property worldName The world name, if applicable
  * @property worldUploadTimes The last upload times in milliseconds since epoch for each world in the response, if this is a DC request
  * @property listingsCount The number of listings retrieved for the request. When using the "listings" limit parameter, this may be different from the number of sale entries returned
  * @property recentHistoryCount The number of sale entries retrieved for the request. When using the "entries" limit parameter, this may be different from the number of sale entries returned
@@ -44,13 +38,9 @@ import kotlinx.serialization.Serializable
  * @property unitsSold The number of items (not sale entries) sold over the retrieved sales
  */
 @JsExport @Serializable data class CurrentlyShown(
-    @SerialName("itemID") val itemId: Int,
-    @SerialName("worldID") val worldId: Short? = null,
     val lastUploadTime: Long,
     val listings: List<Listing>? = null,
     val recentHistory: List<Sale>? = null,
-    val dcName: DataCenter? = null,
-    val regionName: String? = null,
     val currentAveragePrice: Double,
     @SerialName("currentAveragePriceNQ") val currentAveragePriceNq: Double,
     @SerialName("currentAveragePriceHQ") val currentAveragePriceHq: Double,
@@ -74,7 +64,6 @@ import kotlinx.serialization.Serializable
     @SerialName("stackSizeHistogramHQ")
     val stackSizeHistogramHq: StackSizeHistogram = null,
 
-    val worldName: World? = null,
     val worldUploadTimes: Map<Short, Long>? = null,
     val listingsCount: Int,
     val recentHistoryCount: Int,

--- a/src/commonMain/kotlin/entities/History.kt
+++ b/src/commonMain/kotlin/entities/History.kt
@@ -2,35 +2,24 @@
 
 package cloud.drakon.ktuniversalis.entities
 
-import cloud.drakon.ktuniversalis.world.DataCenter
-import cloud.drakon.ktuniversalis.world.World
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * @property itemId The item ID
- * @property worldId The world ID, if applicable
  * @property lastUploadTime The last upload time for this endpoint, in milliseconds since the UNIX epoch
  * @property entries The historical sales
- * @property dcName The DC name, if applicable
- * @property regionName The region name, if applicable
  * @property stackSizeHistogram A map of quantities to sale counts, representing the number of sales of each quantity
  * @property stackSizeHistogramNq A map of quantities to NQ sale counts, representing the number of sales of each quantity
  * @property stackSizeHistogramHq A map of quantities to HQ sale counts, representing the number of sales of each quantity
  * @property regularSaleVelocity The average number of sales per day, over the past seven days (or the entirety of the shown sales, whichever comes first)
  * @property nqSaleVelocity The average number of NQ sales per day, over the past seven days (or the entirety of the shown sales, whichever comes first)
  * @property hqSaleVelocity The average number of HQ sales per day, over the past seven days (or the entirety of the shown sales, whichever comes first)
- * @property worldName The world name, if applicable
  */
 @JsExport @Serializable data class History(
-    @SerialName("itemID") val itemId: Int,
-    @SerialName("worldID") val worldId: Short? = null,
     val lastUploadTime: Long,
     val entries: List<MinimizedSale>? = null,
-    val dcName: DataCenter? = null,
-    val regionName: String? = null,
     val stackSizeHistogram: StackSizeHistogram = null,
 
     @SerialName("stackSizeHistogramNQ")
@@ -42,5 +31,4 @@ import kotlinx.serialization.Serializable
     val regularSaleVelocity: Double,
     val nqSaleVelocity: Double,
     val hqSaleVelocity: Double,
-    val worldName: World? = null,
 ): MarketBoard

--- a/src/commonMain/kotlin/entities/Multi.kt
+++ b/src/commonMain/kotlin/entities/Multi.kt
@@ -11,7 +11,6 @@ import kotlinx.serialization.Serializable
 /**
  * @property itemIds The item IDs that were requested
  * @property items The item data that was requested, keyed on the item ID
- * @property worldId The ID of the world requested, if applicable
  * @property dcName The name of the DC requested, if applicable
  * @property regionName The name of the region requested, if applicable
  * @property unresolvedItems A list of IDs that could not be resolved to any item data
@@ -20,7 +19,6 @@ import kotlinx.serialization.Serializable
 @JsExport @Serializable data class Multi<T: MarketBoard>(
     @SerialName("itemIDs") val itemIds: List<Int>? = null,
     val items: Map<Int, T>? = null,
-    @SerialName("worldID") val worldId: Short? = null,
     val dcName: DataCenter? = null,
     val regionName: String? = null,
     val unresolvedItems: List<Int>? = null,


### PR DESCRIPTION
Remove redundant class properties. These properties either:
- were only returned when the function that returned them contained them as a parameter (in which case they were already known)
- were not useful within the library (i.e returning a world ID instead of a `World` enum)