### PR TITLE
Deprecate `MarketBoard`

### DIFF
--- a/src/commonMain/kotlin/entities/MarketBoard.kt
+++ b/src/commonMain/kotlin/entities/MarketBoard.kt
@@ -5,4 +5,7 @@ package cloud.drakon.ktuniversalis.entities
 import kotlin.js.ExperimentalJsExport
 import kotlin.js.JsExport
 
-@JsExport sealed interface MarketBoard
+@Deprecated(
+    "Will be removed when union types are available within Kotlin.",
+    level = DeprecationLevel.WARNING
+) @JsExport sealed interface MarketBoard


### PR DESCRIPTION
This was never documented, only ever existed as an internal API, and can be removed when union types are available in Kotlin.