### PR TITLE
Remove North America region check and add missing worlds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
     id("org.jetbrains.dokka") version "1.9.0"
 
     id("org.jetbrains.kotlinx.kover") version "0.7.3"
-    id("org.sonarqube") version "4.3.1.3277"
+    id("org.sonarqube") version "4.4.1.3373"
 }
 
 buildscript {
@@ -52,7 +52,7 @@ kotlin {
     }
 
     sourceSets {
-        val ktorVersion = "2.3.4"
+        val ktorVersion = "2.3.5"
 
         val commonMain by getting {
             dependencies {

--- a/src/commonMain/kotlin/GetMarketBoardCurrentData.kt
+++ b/src/commonMain/kotlin/GetMarketBoardCurrentData.kt
@@ -135,7 +135,7 @@ suspend fun getMarketBoardCurrentData(
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
 ): CurrentlyShown = getMarketBoardCurrentDataArray(
-    if (region == Region.NorthAmerica) "North-America" else region.name,
+    region.toString(),
     intArrayOf(itemId),
     listings,
     entries,
@@ -231,7 +231,7 @@ suspend fun getMarketBoardCurrentData(
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
 ): Multi<CurrentlyShown> = getMarketBoardCurrentDataArray(
-    if (region == Region.NorthAmerica) "North-America" else region.name,
+    region.toString(),
     itemIds,
     listings,
     entries,

--- a/src/commonMain/kotlin/GetMarketBoardSaleHistory.kt
+++ b/src/commonMain/kotlin/GetMarketBoardSaleHistory.kt
@@ -98,7 +98,7 @@ suspend fun getMarketBoardSaleHistory(
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
 ): History = getMarketBoardSaleHistoryArray(
-    if (region == Region.NorthAmerica) "North-America" else region.name,
+    region.toString(),
     intArrayOf(itemId),
     entriesToReturn,
     statsWithin,
@@ -159,7 +159,7 @@ suspend fun getMarketBoardSaleHistory(
     statsWithin: Int? = null,
     entriesWithin: Int? = null,
 ): Multi<History> = getMarketBoardSaleHistoryArray(
-    if (region == Region.NorthAmerica) "North-America" else region.name,
+    region.toString(),
     itemIds,
     entriesToReturn,
     statsWithin,

--- a/src/commonMain/kotlin/world/IdToWorld.kt
+++ b/src/commonMain/kotlin/world/IdToWorld.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktuniversalis.world
 
 internal val idToWorld = mapOf(
-    0.toShort() to World.Null,
     21.toShort() to World.Ravana,
     22.toShort() to World.Bismarck,
     23.toShort() to World.Asura,
@@ -121,4 +120,4 @@ internal val idToWorld = mapOf(
     2080.toShort() to World.펜리르,
     3000.toShort() to World.Cloudtest01,
     3001.toShort() to World.Cloudtest02,
-)
+).withDefault { World.UnsupportedWorld }

--- a/src/commonMain/kotlin/world/IdToWorld.kt
+++ b/src/commonMain/kotlin/world/IdToWorld.kt
@@ -1,6 +1,7 @@
 package cloud.drakon.ktuniversalis.world
 
 internal val idToWorld = mapOf(
+    0.toShort() to World.Null,
     21.toShort() to World.Ravana,
     22.toShort() to World.Bismarck,
     23.toShort() to World.Asura,
@@ -118,4 +119,6 @@ internal val idToWorld = mapOf(
     2077.toShort() to World.모그리,
     2078.toShort() to World.톤베리,
     2080.toShort() to World.펜리르,
+    3000.toShort() to World.Cloudtest01,
+    3001.toShort() to World.Cloudtest02,
 )

--- a/src/commonMain/kotlin/world/Region.kt
+++ b/src/commonMain/kotlin/world/Region.kt
@@ -8,5 +8,11 @@ import kotlin.js.JsExport
 
 @JsExport @Serializable
 enum class Region {
-    Japan, Europe, NorthAmerica, Oceania, China
+    Japan,
+    Europe,
+    NorthAmerica {
+        override fun toString() = "North-America"
+    },
+    Oceania,
+    China
 }

--- a/src/commonMain/kotlin/world/World.kt
+++ b/src/commonMain/kotlin/world/World.kt
@@ -127,6 +127,6 @@ enum class World {
     펜리르,
     Cloudtest01,
     Cloudtest02,
-    @Deprecated("Workaround for Universalis sometimes returning a non-existent world ID of 0.")
-    Null,
+    @Deprecated("Default value if the returned world is not supported by KtUniversalis.")
+    UnsupportedWorld,
 }

--- a/src/commonMain/kotlin/world/World.kt
+++ b/src/commonMain/kotlin/world/World.kt
@@ -125,4 +125,8 @@ enum class World {
     모그리,
     톤베리,
     펜리르,
+    Cloudtest01,
+    Cloudtest02,
+    @Deprecated("Workaround for Universalis sometimes returning a non-existent world ID of 0.")
+    Null,
 }

--- a/src/jsMain/kotlin/GetMarketBoardCurrentData.js.kt
+++ b/src/jsMain/kotlin/GetMarketBoardCurrentData.js.kt
@@ -117,7 +117,7 @@ fun getMarketBoardCurrentDataAsync(
     entriesWithin: Int? = null,
 ): Promise<CurrentlyShown> = GlobalScope.promise {
     getMarketBoardCurrentDataArray(
-        if (region == Region.NorthAmerica) "North-America" else region.name,
+        region.toString(),
         intArrayOf(itemId),
         listings,
         entries,

--- a/src/jsMain/kotlin/GetMarketBoardSaleHistory.js.kt
+++ b/src/jsMain/kotlin/GetMarketBoardSaleHistory.js.kt
@@ -89,7 +89,7 @@ fun getMarketBoardSaleHistoryAsync(
     entriesWithin: Int? = null,
 ): Promise<History> = GlobalScope.promise {
     getMarketBoardSaleHistoryArray(
-        if (region == Region.NorthAmerica) "North-America" else region.name,
+        region.toString(),
         intArrayOf(itemId),
         entriesToReturn,
         statsWithin,

--- a/src/jvmMain/kotlin/GetMarketBoardCurrentData.jvm.kt
+++ b/src/jvmMain/kotlin/GetMarketBoardCurrentData.jvm.kt
@@ -124,7 +124,7 @@ fun getMarketBoardCurrentDataAsync(
     entriesWithin: Int? = null,
 ): CompletableFuture<CurrentlyShown> = GlobalScope.future {
     getMarketBoardCurrentDataArray(
-        if (region == Region.NorthAmerica) "North-America" else region.name,
+        region.toString(),
         intArrayOf(itemId),
         listings,
         entries,
@@ -241,7 +241,7 @@ fun getMarketBoardCurrentDataAsync(
     entriesWithin: Int? = null,
 ): CompletableFuture<Multi<CurrentlyShown>> = GlobalScope.future {
     getMarketBoardCurrentDataArray(
-        if (region == Region.NorthAmerica) "North-America" else region.name,
+        region.toString(),
         itemIds,
         listings,
         entries,

--- a/src/jvmMain/kotlin/GetMarketBoardSaleHistory.jvm.kt
+++ b/src/jvmMain/kotlin/GetMarketBoardSaleHistory.jvm.kt
@@ -96,7 +96,7 @@ fun getMarketBoardSaleHistoryAsync(
     entriesWithin: Int? = null,
 ): CompletableFuture<History> = GlobalScope.future {
     getMarketBoardSaleHistoryArray(
-        if (region == Region.NorthAmerica) "North-America" else region.name,
+        region.toString(),
         intArrayOf(itemId),
         entriesToReturn,
         statsWithin,
@@ -178,7 +178,7 @@ fun getMarketBoardSaleHistoryAsync(
     entriesWithin: Int? = null,
 ): CompletableFuture<Multi<History>> = GlobalScope.future {
     getMarketBoardSaleHistoryArray(
-        if (region == Region.NorthAmerica) "North-America" else region.name,
+        region.toString(),
         itemIds,
         entriesToReturn,
         statsWithin,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Release Notes:**

- **New Feature**: Added support for two new worlds, `Cloudtest01` and `Cloudtest02`.
- **Refactor**: Simplified region name conversion in `getMarketBoardCurrentData` and `getMarketBoardSaleHistory` functions across all platforms. This change improves code readability and maintainability.
- **Chore**: Updated the versions of "org.sonarqube" plugin and "ktor" library to enhance performance and security.
- **Deprecation**: Deprecated the `Null` world in favor of a new `UnsupportedWorld` enum value to handle unsupported worlds more gracefully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->